### PR TITLE
Add support for user defined password hash algorithm

### DIFF
--- a/src/IdentityServer3.Contrib.Membership/MembershipOptions.cs
+++ b/src/IdentityServer3.Contrib.Membership/MembershipOptions.cs
@@ -13,6 +13,7 @@ namespace IdentityServer3.Contrib.Membership
             MaxInvalidPasswordAttempts = 5;
             PasswordAttemptWindow = 10;
             IdentityProvider = "idsvr";
+            PasswordHashAlgorithmName = "SHA1";
         }
 
         /// <summary>
@@ -45,5 +46,10 @@ namespace IdentityServer3.Contrib.Membership
         /// The Identity Provider
         /// </summary>
         public string IdentityProvider { get; set; }
+        
+        /// <summary>
+        /// The hash algorithm that will be used for the password hashing
+        /// </summary>
+        public string PasswordHashAlgorithmName { get; set; }
     }
 }

--- a/src/IdentityServer3.Contrib.Membership/MembershipPasswordHasher.cs
+++ b/src/IdentityServer3.Contrib.Membership/MembershipPasswordHasher.cs
@@ -1,6 +1,9 @@
 ﻿// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using IdentityServer3.Contrib.Membership.Helpers;
+
 namespace IdentityServer3.Contrib.Membership
 {
     using System;
@@ -11,6 +14,20 @@ namespace IdentityServer3.Contrib.Membership
     /// <summary>Membership Password Encrypt / Hasher</summary>
     public class MembershipPasswordHasher : IMembershipPasswordHasher
     {
+        private readonly string hashAlgorithmName;
+
+        public MembershipPasswordHasher(MembershipOptions options)
+        {
+            options.ThrowIfNull(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.PasswordHashAlgorithmName))
+            {
+                var s = nameof(options.PasswordHashAlgorithmName);
+                throw new ArgumentException(s);
+            }
+            
+            hashAlgorithmName = options.PasswordHashAlgorithmName;
+        }
+        
         /// <summary>Encrypts a password using the given format and salt</summary>
         /// <param name="password">The password to encrypt / hash</param>
         /// <param name="passwordFormat">The format to use 0 = clear, 1 = encrypt, 2 = hash</param>
@@ -29,7 +46,7 @@ namespace IdentityServer3.Contrib.Membership
             if (passwordFormat == 1)
             {
                 // MembershipPasswordFormat.Hashed 
-                HashAlgorithm hm = HashAlgorithm.Create("SHA1");
+                HashAlgorithm hm = HashAlgorithm.Create(hashAlgorithmName);
                 if (hm is KeyedHashAlgorithm)
                 {
                     KeyedHashAlgorithm kha = (KeyedHashAlgorithm)hm;

--- a/src/IdentityServer4.Contrib.Membership/MembershipOptions.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipOptions.cs
@@ -13,6 +13,7 @@ namespace IdentityServer4.Contrib.Membership
             MaxInvalidPasswordAttempts = 5;
             PasswordAttemptWindow = 10;
             IdentityProvider = "idsvr";
+            PasswordHashAlgorithmName = "SHA1";
         }
 
         /// <summary>
@@ -45,5 +46,10 @@ namespace IdentityServer4.Contrib.Membership
         /// The Identity Provider
         /// </summary>
         public string IdentityProvider { get; set; }
+        
+        /// <summary>
+        /// The hash algorithm that will be used for the password hashing
+        /// </summary>
+        public string PasswordHashAlgorithmName { get; set; }
     }
 }

--- a/src/IdentityServer4.Contrib.Membership/MembershipPasswordHasher.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipPasswordHasher.cs
@@ -11,6 +11,18 @@ namespace IdentityServer4.Contrib.Membership
     /// <summary>Membership Password Encrypt / Hasher</summary>
     public class MembershipPasswordHasher : IMembershipPasswordHasher
     {
+        private readonly string hashAlgorithmName;
+
+        public MembershipPasswordHasher(MembershipOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(options.PasswordHashAlgorithmName))
+            {
+                throw new ArgumentException(nameof(options.PasswordHashAlgorithmName));
+            }
+            
+            hashAlgorithmName = options.PasswordHashAlgorithmName;
+        }
+        
         /// <summary>Encrypts a password using the given format and salt</summary>
         /// <param name="password">The password to encrypt / hash</param>
         /// <param name="passwordFormat">The format to use 0 = clear, 1 = encrypt, 2 = hash</param>
@@ -28,7 +40,7 @@ namespace IdentityServer4.Contrib.Membership
 
             if (passwordFormat == 1)
             {
-                HashAlgorithm hm = SHA1.Create();
+                HashAlgorithm hm = HashAlgorithm.Create(hashAlgorithmName);
 
                 // MembershipPasswordFormat.Hashed                 
                 if (hm is KeyedHashAlgorithm)


### PR DESCRIPTION
Add support to use custom hash algorithm using the MembershipOptions in AddMembershipService. 
Not sure why HashAlgorithm.Create was replaced with a hardcoded SHA1.Create at some point. Seems to be available in both netstandard2.0 and net452.