### PR TITLE
Make version that works with AspNet Core 3.1

### DIFF
--- a/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
+++ b/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Copyright>Copyright © 2017 onwards</Copyright>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp31</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -15,12 +15,12 @@
     <Description>An IdentityServer plugin for authenticating against a ASP.NET 2.0 Membership Database</Description>
     <PackageTags>IdentityServer</PackageTags>
     <PackageReleaseNotes>https://github.com/sma73648/identityserver-contrib-membership/releases</PackageReleaseNotes>
-    <Version>$(Version)</Version>
+    <Version>3.1.2</Version>
     <PackageOutputPath>$(PackageOutputPath)</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="2.3.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    <PackageReference Include="IdentityServer4" Version="3.1.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/src/IdentityServer4.Contrib.Membership/MembershipClaimsService.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipClaimsService.cs
@@ -42,7 +42,7 @@ namespace IdentityServer4.Contrib.Membership
                 new Claim(JwtClaimTypes.Email, user.Email),
 
                 new Claim(JwtClaimTypes.IdentityProvider, options.IdentityProvider),
-                new Claim(JwtClaimTypes.AuthenticationTime, DateTime.UtcNow.ToEpochTime().ToString()),
+                new Claim(JwtClaimTypes.AuthenticationTime, DateTime.Now.ToUtcEpoch().ToString()),
 
                 new Claim(MembershipClaimTypes.AccountCreated, user.AccountCreated.ToUtcEpoch().ToString()),
                 new Claim(MembershipClaimTypes.LastActivity, user.LastActivity.ToUtcEpoch().ToString()),

--- a/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/IdentityServer4.Contrib.Membership.ClientDemo.csproj
+++ b/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/IdentityServer4.Contrib.Membership.ClientDemo.csproj
@@ -1,20 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <OutputType>Exe</OutputType>
         <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\IdentityServer4.Contrib.Membership\IdentityServer4.Contrib.Membership.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     </ItemGroup>
 </Project>

--- a/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/Startup.cs
+++ b/src/samples/IdentityServer4.Contrib.Membership.ClientDemo/Startup.cs
@@ -17,7 +17,7 @@ namespace IdentityServer4.Contrib.Membership.ClientDemo
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc(mvc => mvc.EnableEndpointRouting = false);
 
             services.AddAuthentication(options =>
                 {

--- a/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
+++ b/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/IdentityServer4.Contrib.Membership.IdsvrDemo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp31</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
     <Configurations>Debug;Release</Configurations>
@@ -11,21 +11,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BundlerMinifier.Core" Version="2.8.391" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />

--- a/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/Startup.cs
+++ b/src/samples/IdentityServer4.Contrib.Membership.IdsvrDemo/Startup.cs
@@ -15,7 +15,7 @@ namespace IdentityServer4.Contrib.Membership.IdsvrDemo
 
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
+        public Startup(IWebHostEnvironment env)
         {
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
@@ -30,7 +30,7 @@ namespace IdentityServer4.Contrib.Membership.IdsvrDemo
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
 
             services.AddIdentityServer()
                     .AddDeveloperSigningCredential()


### PR DESCRIPTION
The main issue is that, IdentityServer4 3.x uses IdentityModel 4.x, which has renamed EpochTimeExtensions, and hence you get a runtime binding error. 
This minimally fixes that version, whilst updating the IdentityServer4.Contrib.Membership Version number to reflect the supported Version Number of IdentityServer4.